### PR TITLE
게이트웨이, 서점, 프론트에 유레카 적용, 개발환경 분리 작업하였습니다.

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -20,42 +20,42 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
-    - name: Set up JDK 17
-      uses: actions/setup-java@v3
-      with:
-        java-version: '11'
-        distribution: 'temurin'
-        cache: maven
-    - name: Build with Maven
-      run: mvn -B package --file pom.xml
+      - uses: actions/checkout@v3
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '11'
+          distribution: 'temurin'
+          cache: maven
+      - name: Build with Maven
+        run: mvn -B package -Dspring.profiles.active=prod --file pom.xml
 
-    # Optional: Uploads the full dependency graph to GitHub to improve the quality of Dependabot alerts this repository can receive
-    - name: Update dependency graph
-      uses: advanced-security/maven-dependency-submission-action@571e99aab1055c2e71a1e2309b9691de18d6b7d6
+      # Optional: Uploads the full dependency graph to GitHub to improve the quality of Dependabot alerts this repository can receive
+      - name: Update dependency graph
+        uses: advanced-security/maven-dependency-submission-action@571e99aab1055c2e71a1e2309b9691de18d6b7d6
 
-    - name : upload file
-      uses: appleboy/scp-action@master
-      with:
-        host: ${{ secrets.SSH_IP }}
-        username: ${{ secrets.SSH_ID }}
-        key: ${{ secrets.SSH_KEY }}
-        port: ${{ secrets.SSH_PORT }}
-        source: "target/*.jar"
-        target: "~/"
-        rm: false
+      - name: upload file
+        uses: appleboy/scp-action@master
+        with:
+          host: ${{ secrets.SSH_IP }}
+          username: ${{ secrets.SSH_ID }}
+          key: ${{ secrets.SSH_KEY }}
+          port: ${{ secrets.SSH_PORT }}
+          source: "target/*.jar"
+          target: "~/"
+          rm: false
 
-    - name: execute shell script
-      uses: appleboy/ssh-action@master
-      with:
-        host: ${{ secrets.SSH_IP }}
-        username: ${{ secrets.SSH_ID }}
-        key: ${{ secrets.SSH_KEY }}
-        port: ${{ secrets.SSH_PORT }}
-        script_stop: true
-        script: "./startup.sh"
-        
-    # sonarqube add
-    - name : Run SonarQube
-      run : mvn sonar:sonar -Dsonar.projectKey=github-action -Dsonar.host.url=${{secrets.SONAR_HOST}} -Dsonar.login=${{secrets.SONAR_TOKEN}}
+      - name: execute shell script
+        uses: appleboy/ssh-action@master
+        with:
+          host: ${{ secrets.SSH_IP }}
+          username: ${{ secrets.SSH_ID }}
+          key: ${{ secrets.SSH_KEY }}
+          port: ${{ secrets.SSH_PORT }}
+          script_stop: true
+          script: "./startup.sh"
+
+      # sonarqube add
+      - name: Run SonarQube
+        run: mvn sonar:sonar -Dsonar.projectKey=github-action -Dsonar.host.url=${{secrets.SONAR_HOST}} -Dsonar.login=${{secrets.SONAR_TOKEN}}
     

--- a/pom.xml
+++ b/pom.xml
@@ -1,99 +1,124 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
-	<modelVersion>4.0.0</modelVersion>
-	<parent>
-		<groupId>org.springframework.boot</groupId>
-		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.7.18</version>
-		<relativePath/> <!-- lookup parent from repository -->
-	</parent>
-	<groupId>shop.bookbom</groupId>
-	<artifactId>gateway</artifactId>
-	<version>0.0.1-SNAPSHOT</version>
-	<name>gateway</name>
-	<description>Demo project for Spring Boot</description>
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>2.7.18</version>
+        <relativePath/> <!-- lookup parent from repository -->
+    </parent>
+    <groupId>shop.bookbom</groupId>
+    <artifactId>gateway</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <name>gateway</name>
+    <description>Demo project for Spring Boot</description>
 
-	<properties>
-		<java.version>11</java.version>
-		<maven.compiler.source>11</maven.compiler.source>
-		<maven.compiler.target>11</maven.compiler.target>
-		<project.build.sourceEncoding>utf-8</project.build.sourceEncoding>
+    <properties>
+        <java.version>11</java.version>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
+        <project.build.sourceEncoding>utf-8</project.build.sourceEncoding>
 
-		<jacoco.version>0.8.8</jacoco.version>
-		<sonar.java.coveragePlugin>jacoco</sonar.java.coveragePlugin>
-		<sonar.dynamicAnalysis>reuseReports</sonar.dynamicAnalysis>
-		<sonar.jacoco.reportPath>${project.basedir}/../target/jacoco.exec</sonar.jacoco.reportPath>
-		<sonar.language>java</sonar.language>
+        <jacoco.version>0.8.8</jacoco.version>
+        <sonar.java.coveragePlugin>jacoco</sonar.java.coveragePlugin>
+        <sonar.dynamicAnalysis>reuseReports</sonar.dynamicAnalysis>
+        <sonar.jacoco.reportPath>${project.basedir}/../target/jacoco.exec</sonar.jacoco.reportPath>
+        <sonar.language>java</sonar.language>
 
-	</properties>
-	<dependencies>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-web</artifactId>
-		</dependency>
+        <spring-cloud.version>2021.0.8</spring-cloud.version>
+    </properties>
 
-		<dependency>
-			<groupId>org.projectlombok</groupId>
-			<artifactId>lombok</artifactId>
-			<optional>true</optional>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-test</artifactId>
-			<scope>test</scope>
-		</dependency>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.springframework.cloud</groupId>
+                <artifactId>spring-cloud-dependencies</artifactId>
+                <version>${spring-cloud.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
-	</dependencies>
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter</artifactId>
+        </dependency>
 
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.springframework.boot</groupId>
-				<artifactId>spring-boot-maven-plugin</artifactId>
-				<configuration>
-					<excludes>
-						<exclude>
-							<groupId>org.projectlombok</groupId>
-							<artifactId>lombok</artifactId>
-						</exclude>
-					</excludes>
-				</configuration>
-			</plugin>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-surefire-plugin</artifactId>
-				<version>3.1.0</version>
-				<configuration>
-					<!-- test skip 하려면 true 설정 -->
-					<skipTests>false</skipTests>
-				</configuration>
-			</plugin>
-			<plugin>
-				<groupId>org.jacoco</groupId>
-				<artifactId>jacoco-maven-plugin</artifactId>
-				<version>0.8.9</version>
-				<executions>
-					<execution>
-						<id>jacoco-initialize</id>
-						<goals>
-							<goal>prepare-agent</goal>
-						</goals>
-					</execution>
-					<execution>
-						<id>jacoco-site</id>
-						<phase>package</phase>
-						<goals>
-							<goal>report</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
-		</plugins>
-	</build>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-starter-gateway</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-starter-netflix-eureka-client</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <configuration>
+                    <excludes>
+                        <exclude>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                        </exclude>
+                    </excludes>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.1.0</version>
+                <configuration>
+                    <!-- test skip 하려면 true 설정 -->
+                    <skipTests>false</skipTests>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.8.9</version>
+                <executions>
+                    <execution>
+                        <id>jacoco-initialize</id>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>jacoco-site</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 
 </project>

--- a/src/main/java/shop/bookbom/gateway/GatewayApplication.java
+++ b/src/main/java/shop/bookbom/gateway/GatewayApplication.java
@@ -2,13 +2,17 @@ package shop.bookbom.gateway;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
+import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
 
+@EnableDiscoveryClient
 @SpringBootApplication
+@ConfigurationPropertiesScan
 public class GatewayApplication {
 
-	public static void main(String[] args) {
-		SpringApplication.run(GatewayApplication.class, args);
+    public static void main(String[] args) {
+        SpringApplication.run(GatewayApplication.class, args);
 
-	}
+    }
 
 }

--- a/src/main/java/shop/bookbom/gateway/actuator/ApplicationStatus.java
+++ b/src/main/java/shop/bookbom/gateway/actuator/ApplicationStatus.java
@@ -1,0 +1,16 @@
+package shop.bookbom.gateway.actuator;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public final class ApplicationStatus {
+    private boolean status = true;
+
+    public void stopService() {
+        this.status = false;
+    }
+
+    public boolean getStatus() {
+        return status;
+    }
+}

--- a/src/main/java/shop/bookbom/gateway/actuator/CustomHealthIndicator.java
+++ b/src/main/java/shop/bookbom/gateway/actuator/CustomHealthIndicator.java
@@ -1,0 +1,22 @@
+package shop.bookbom.gateway.actuator;
+
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.HealthIndicator;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CustomHealthIndicator implements HealthIndicator {
+    private final ApplicationStatus applicationStatus;
+
+    public CustomHealthIndicator(ApplicationStatus applicationStatus) {
+        this.applicationStatus = applicationStatus;
+    }
+
+    @Override
+    public Health health() {
+        if (!applicationStatus.getStatus()) {
+            return Health.down().build();
+        }
+        return Health.up().withDetail("service", "start").build();
+    }
+}

--- a/src/main/java/shop/bookbom/gateway/config/RouteLocatorConfig.java
+++ b/src/main/java/shop/bookbom/gateway/config/RouteLocatorConfig.java
@@ -1,0 +1,44 @@
+package shop.bookbom.gateway.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
+import org.springframework.cloud.gateway.route.RouteLocator;
+import org.springframework.cloud.gateway.route.builder.RouteLocatorBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ConfigurationProperties(prefix = "bookbom")
+@ConfigurationPropertiesScan
+public class RouteLocatorConfig {
+    @Bean
+    public RouteLocator myRoute(RouteLocatorBuilder builder) {
+
+//        return builder.routes()
+//                .route("shop",
+//                        p -> p.path(shopUrlPattern).and()
+//                                .uri("lb://BOOKBOM-SHOP")
+//                )
+//                .build();
+
+        // eureka 프로젝트 실행한 뒤 front, shop, gateway 을 유레카 인스턴스로 등록(실행) 한 뒤
+        // localhost:8080/index.html 으로 호출한 경우 가중치에 맞게 리다이렉트 됨을 확인했습니다
+        return builder.routes()
+                .route("gateway-test-shop",
+                        p -> p.path("/index.html").and().weight("index", 70).uri("http://localhost:8090/")
+                )
+                .route("gateway-test-front",
+                        p -> p.path("/index.html").and().weight("index", 30).uri("http://localhost:8091/")
+                )
+                .build();
+
+//        return builder.routes()
+//                .route("get_route", r -> r.path("/account")
+//                        .filters(o->o.addRequestHeader("uuid", UUID.randomUUID().toString()))
+//                        .uri("http://httpbin.org"))
+//                .build();
+
+        //http://httpbin.org/get
+
+    }
+}

--- a/src/main/java/shop/bookbom/gateway/config/RouteLocatorConfig.java
+++ b/src/main/java/shop/bookbom/gateway/config/RouteLocatorConfig.java
@@ -1,34 +1,45 @@
 package shop.bookbom.gateway.config;
 
+import lombok.RequiredArgsConstructor;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
+import org.springframework.boot.context.properties.ConstructorBinding;
 import org.springframework.cloud.gateway.route.RouteLocator;
 import org.springframework.cloud.gateway.route.builder.RouteLocatorBuilder;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
 
-@Configuration
 @ConfigurationProperties(prefix = "bookbom")
-@ConfigurationPropertiesScan
+@RequiredArgsConstructor
+@ConstructorBinding
 public class RouteLocatorConfig {
+    private final String shopUri;
+    private final String frontUri;
+    private final String authUri;
+    private final String batchUri;
+    private final String couponUri;
+
     @Bean
     public RouteLocator myRoute(RouteLocatorBuilder builder) {
 
-//        return builder.routes()
-//                .route("shop",
-//                        p -> p.path(shopUrlPattern).and()
-//                                .uri("lb://BOOKBOM-SHOP")
-//                )
-//                .build();
-
-        // eureka 프로젝트 실행한 뒤 front, shop, gateway 을 유레카 인스턴스로 등록(실행) 한 뒤
-        // localhost:8080/index.html 으로 호출한 경우 가중치에 맞게 리다이렉트 됨을 확인했습니다
         return builder.routes()
-                .route("gateway-test-shop",
-                        p -> p.path("/index.html").and().weight("index", 70).uri("http://localhost:8090/")
+                .route("bookbom-front",
+                        p -> p.path(frontUri).and()
+                                .uri("lb://BOOKBOM-FRONT")
                 )
-                .route("gateway-test-front",
-                        p -> p.path("/index.html").and().weight("index", 30).uri("http://localhost:8091/")
+                .route("bookbom-shop",
+                        p -> p.path(shopUri).and()
+                                .uri("lb://BOOKBOM-SHOP")
+                )
+                .route("bookbom-auth",
+                        p -> p.path(authUri).and()
+                                .uri("lb://BOOKBOM-AUTH")
+                )
+                .route("bookbom-batch",
+                        p -> p.path(batchUri).and()
+                                .uri("lb://BOOKBOM-BATCH")
+                )
+                .route("bookbom-coupon",
+                        p -> p.path(couponUri).and()
+                                .uri("lb://BOOKBOM-COUPON")
                 )
                 .build();
 
@@ -37,8 +48,6 @@ public class RouteLocatorConfig {
 //                        .filters(o->o.addRequestHeader("uuid", UUID.randomUUID().toString()))
 //                        .uri("http://httpbin.org"))
 //                .build();
-
-        //http://httpbin.org/get
 
     }
 }

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -1,7 +1,6 @@
 # 개발환경 url
+# 접속 설정
+bookbom.eureka-address:127.0.0.1
+bookbom.eureka-port:8761
 # 유레카 서버 주소
-eureka.client.service-url.defaultZone=http://admin:1234@localhost:8761/eureka
-# 연결 정보
-eureka.instance.hostname=localhost
-# 개발 api 요청
-bookbom.shop-url-pattern=/shop/**
+eureka.client.service-url.defaultZone=http://admin:1234@${bookbom.eureka-address}:${bookbom.eureka-port}/eureka

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -1,0 +1,7 @@
+# 개발환경 url
+# 유레카 서버 주소
+eureka.client.service-url.defaultZone=http://admin:1234@localhost:8761/eureka
+# 연결 정보
+eureka.instance.hostname=localhost
+# 개발 api 요청
+bookbom.shop-url-pattern=/shop/**

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -1,7 +1,6 @@
 # 상용환경 url
+# 접속 설정
+bookbom.eureka-address:192.168.0.55
+bookbom.eureka-port:8761
 # 유레카 서버 주소
-eureka.client.service-url.defaultZone=http://bookbom_admin:1q2w3e4r@localhost:8761/eureka
-# 연결 정보
-eureka.instance.hostname=localhost
-# 상용 api 요청
-bookbom.shop-url-pattern=/shop/**
+eureka.client.service-url.defaultZone=http://bookbom_admin:1q2w3e4r@${bookbom.eureka-address}:${bookbom.eureka-port}/eureka

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -1,0 +1,7 @@
+# 상용환경 url
+# 유레카 서버 주소
+eureka.client.service-url.defaultZone=http://bookbom_admin:1q2w3e4r@localhost:8761/eureka
+# 연결 정보
+eureka.instance.hostname=localhost
+# 상용 api 요청
+bookbom.shop-url-pattern=/shop/**

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -3,4 +3,4 @@
 bookbom.eureka-address:192.168.0.55
 bookbom.eureka-port:8761
 # 유레카 서버 주소
-eureka.client.service-url.defaultZone=http://bookbom_admin:1q2w3e4r@${bookbom.eureka-address}:${bookbom.eureka-port}/eureka
+eureka.client.service-url.defaultZone=http://bom_admin:1q2w3e4r@${bookbom.eureka-address}:${bookbom.eureka-port}/eureka

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,18 @@
-
+# 기본 설정
+server.port=8080
+spring.application.name=bookbom-gateway
+# 유레카 클라이언트 설정
+eureka.client.register-with-eureka=true
+eureka.client.fetch-registry=true
+eureka.instance.prefer-ip-address=true
+eureka.instance.instance-id=bookbom-gateway
+# endpoint 설정
+management.endpoint.health.status.order=DOWN, UP
+management.endpoint.jolokia.enabled=true
+management.endpoint.metrics.enabled=true
+management.endpoint.pause.enabled=true
+management.endpoint.resume.enabled=true
+management.endpoint.restart.enabled=true
+management.endpoint.shutdown.enabled=true
+management.info.env.enabled=true
+management.endpoints.web.exposure.include=health,info

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,5 +1,5 @@
 # 기본 설정
-server.port=8080
+server.port=8880
 spring.application.name=bookbom-gateway
 # 유레카 클라이언트 설정
 eureka.client.register-with-eureka=true
@@ -16,3 +16,9 @@ management.endpoint.restart.enabled=true
 management.endpoint.shutdown.enabled=true
 management.info.env.enabled=true
 management.endpoints.web.exposure.include=health,info
+# api 요청 주소
+bookbom.shop-uri=/shop/**
+bookbom.front-uri=/front/**
+bookbom.auth-uri=/auth/**
+bookbom.batch-uri=/batch/**
+bookbom.coupon-uri=/coupon/**


### PR DESCRIPTION
# 설명

- bookbom-gateway 를 eureka client로 설정하였습니다.
- bookbom-shop, bookbom-front 또한 테스트를 위해 eureka client로 설정하였습니다.
- 유레카 서버에 등록한 뒤 게이트웨이 주소로 url 호출 시 라우팅 설정한 주소로 이동됩니다.
- 게이트웨이가 8080포트, shop이 8090, front가 8091이며 테스트를 위해 각각 70:30 비율로 라우팅되도록 임의로 설정하였습니다.
- localhost:8080/index.html 호출 시 유사한 비율로 라우팅 됨을 확인하였습니다.
- 또한 개발환경과 상용환경을 분리하기 위해 .properties 파일 추가로 생성하였습니다.

또한 위 설정 작업을 다른 리포지토리에도 적용할 예정입니다.
이때 리포지토리마다 PR 하지 말고 메인 브랜치에 그대로 작업할까 하는데 이에 대한 찬반 의견 부탁드리겠습니다.